### PR TITLE
Converting HTTPBody data to string for access signature

### DIFF
--- a/Pod/Classes/Coinbase.m
+++ b/Pod/Classes/Coinbase.m
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSUInteger, CoinbaseAuthenticationType) {
     if (self.authenticationType == CoinbaseAuthenticationTypeAPIKey) {
         // HMAC auth
         NSInteger nonce = [[NSDate date] timeIntervalSince1970] * 100000;
-        NSString *toBeSigned = [NSString stringWithFormat:@"%ld%@%@", (long)nonce, [URL absoluteString], body ? body : @""];
+        NSString *toBeSigned = [NSString stringWithFormat:@"%ld%@%@", (long)nonce, [URL absoluteString], body ? [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding] : @""];
         NSString *signature = [self generateSignature: toBeSigned];
         [request setValue:self.apiKey forHTTPHeaderField:@"ACCESS_KEY"];
         [request setValue:signature forHTTPHeaderField:@"ACCESS_SIGNATURE"];


### PR DESCRIPTION
I noticed any of my requests containing parameters using the API key auth method were receiving an `ACCESS_SIGNATURE does not validate` error from the sandbox api. Found that your toBeSigned variable was not converting the HTTPBody data to a string properly.
