### PR TITLE
Improve app switch interface

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - coinbase-official (2.0.1):
-    - coinbase-official/OAuth (= 2.0.1)
-  - coinbase-official/OAuth (2.0.1)
+  - coinbase-official (2.1):
+    - coinbase-official/OAuth (= 2.1)
+  - coinbase-official/OAuth (2.1)
   - Expecta (0.3.1)
   - Expecta+Snapshots (1.2.1):
     - Expecta
@@ -21,10 +21,10 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  coinbase-official: bc9b3ed0b936f2b3cb2db655f7d744ab27d91396
+  coinbase-official: 18e19a9fe9a944e65fdfd24ab7d5437b80f4330d
   Expecta: 03aabd0a89d8dea843baecb19a7fd7466a69a31d
   Expecta+Snapshots: 30c28e3d8104665ee70e32df1cfc030bb37a8a6c
   FBSnapshotTestCase: 9053afee1d66b4c7c313fcb0ae582a5e47bea9d0
   Specta: 9141310f46b1f68b676650ff2854e1ed0b74163a
 
-COCOAPODS: 0.36.0.rc.1
+COCOAPODS: 0.35.0

--- a/Pod/Classes/CoinbaseOAuth.h
+++ b/Pod/Classes/CoinbaseOAuth.h
@@ -1,6 +1,23 @@
 #import <Foundation/Foundation.h>
 #import "CoinbaseDefines.h"
 
+///  Indicates where user authentication takes place
+typedef NS_ENUM(NSInteger, CoinbaseOAuthAuthenticationMechanism){
+    ///  Neither app switch nor authentication occured
+    CoinbaseOAuthMechanismNone = NO,
+    ///  The user authenticated with Coinbase in Mobile Safari
+    CoinbaseOAuthMechanismBrowser,
+    /// The user authenticated with Coinbase in the Coinbase app
+    CoinbaseOAuthMechanismApp,
+};
+
+///  The key in an NSError userInfo dictionary where the coinbase specific error code is returned.
+///
+///  For example, when the return URL contains error=acccess_denied, the error you receive in
+///  finishOAuthAuthenticationForUrl:clientId:clientSecret:completion: will contain @"access_denied"
+///  in the userInfo dictionary.
+extern NSString *const CoinbaseOAuthErrorUserInfoKey;
+
 /// `CoinbaseOAuth` contains methods to authenticate users through OAuth2. After obtaining an
 /// access token using this class, you can call Coinbase API methods
 /// using `[Coinbase coinbaseWithOAuthAccessToken:]`.
@@ -15,10 +32,12 @@
 
 /// Start the OAuth authentication process. This will open a different application to complete the
 /// authentication flow.
-+ (BOOL)startOAuthAuthenticationWithClientId:(NSString *)clientId
-                                       scope:(NSString *)scope
-                                 redirectUri:(NSString *)redirectUri
-                                        meta:(NSDictionary *)meta;
+///
+/// @return the mechanism of authentication. Example: CoinbaseOAuthMechanismApp
++ (CoinbaseOAuthAuthenticationMechanism)startOAuthAuthenticationWithClientId:(NSString *)clientId
+                                                                       scope:(NSString *)scope
+                                                                 redirectUri:(NSString *)redirectUri
+                                                                        meta:(NSDictionary *)meta;
 
 /// Finish the OAuth authentication process. This should be called when your application is opened
 /// for a Coinbase OAuth URI.


### PR DESCRIPTION
#### Changes
- Expose authentication mechnanism used for oauth flow upon `start…`
- Expose Coinbase error code, in addition to `error_description`, so
  that clients can differentiate `user_denied` from other error cases
#### Background

Our main motivation for these changes was being able to collect more valuable analytics on user behavior during Coinbase OAuth flows.

_Note_: there is a change to the return type of `startOAuthAuthentication`, which we consider to be essentially backwards compatible, since the truthy and falsy return values are consistent with this change.

Thanks!

cc/ @david-bt
