### PR TITLE
Import UIKit framework in CoinbaseOAuth

### DIFF
--- a/Pod/Classes/OAuth/CoinbaseOAuth.h
+++ b/Pod/Classes/OAuth/CoinbaseOAuth.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "CoinbaseDefines.h"
 
 ///  Indicates where user authentication takes place


### PR DESCRIPTION
The CoinbaseOAuth class uses `UIApplication`, which is a `UIKit` class. I've fixed the header file to import `UIKit` instead of `Foundation`.
