### PR TITLE
Swift 3 and extensions

### DIFF
--- a/Example/coinbase.xcodeproj/project.pbxproj
+++ b/Example/coinbase.xcodeproj/project.pbxproj
@@ -647,6 +647,9 @@
 				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Isaac Waller";
 				TargetAttributes = {
+					6003F589195388D20070C39A = {
+						LastSwiftMigration = 0800;
+					};
 					D7F1473C1B03154700B13F98 = {
 						CreatedOnToolsVersion = 6.3.1;
 						TestTargetID = 6003F589195388D20070C39A;
@@ -990,6 +993,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "coinbase/coinbase-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1008,6 +1012,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "coinbase/coinbase-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/Example/coinbase/CoinbaseBuySellViewController.swift
+++ b/Example/coinbase/CoinbaseBuySellViewController.swift
@@ -16,7 +16,7 @@ class CoinbaseBuySellViewController: UIViewController {
 
     override func viewDidLoad() {
 
-        Coinbase().getBuyPrice { (btc: CoinbaseBalance?, fees: Array?, subtotal: CoinbaseBalance?, total: CoinbaseBalance?, error: NSError?) in
+        Coinbase().getBuyPrice { (btc: CoinbaseBalance?, fees: [Any]?, subtotal: CoinbaseBalance?, total: CoinbaseBalance?, error: Error?) in
 
             if let error = error {
                 let alertView = UIAlertView(title: "Error", message: error.localizedDescription, delegate: nil, cancelButtonTitle: "OK")
@@ -26,17 +26,17 @@ class CoinbaseBuySellViewController: UIViewController {
             }
         }
 
-        Coinbase().getSellPrice { (btc: CoinbaseBalance?, fees: Array?, subtotal: CoinbaseBalance?, total: CoinbaseBalance?, error: NSError?) in
+        Coinbase().getSellPrice { (btc: CoinbaseBalance?, fees: [Any]?, subtotal: CoinbaseBalance?, total: CoinbaseBalance?, error: Error?) in
 
             if let error = error {
                 let alertView = UIAlertView(title: "Error", message: error.localizedDescription, delegate: nil, cancelButtonTitle: "OK")
                 alertView.show()
             } else {
-                self.sellTotal.text = "Sell price: \(total!.amount) BTC"
+                self.sellTotal.text = "Sell price: \(total!.amount!) BTC"
             }
         }
 
-        Coinbase().getSpotRate { (spotPrice: CoinbaseBalance?, error: NSError?) in
+        Coinbase().getSpotRate { (spotPrice: CoinbaseBalance?, error: Error?) in
 
             if let error = error {
                 let alertView = UIAlertView(title: "Error", message: error.localizedDescription, delegate: nil, cancelButtonTitle: "OK")

--- a/Example/coinbase/CoinbaseCurrenciesViewController.swift
+++ b/Example/coinbase/CoinbaseCurrenciesViewController.swift
@@ -9,12 +9,13 @@ class CoinbaseCurrenciesViewController: UITableViewController {
 
     var currencies : [CoinbaseCurrency]?
 
-    override func viewDidAppear(animated: Bool) {
+    override func viewDidAppear(_ animated: Bool) {
 
-        Coinbase.setRequestTimeoutInterval(NSNumber(double: 15))
+        Coinbase.setRequestTimeoutInterval(NSNumber(value: 15 as Double))
         
         // Load currencies
-        Coinbase().getSupportedCurrencies() { (response: Array?, error: NSError?) in
+        
+        Coinbase().getSupportedCurrencies() { (response: [Any]?, error: Error?) in
 
             if let currencies = response as? [CoinbaseCurrency] {
                 self.currencies = currencies
@@ -26,7 +27,7 @@ class CoinbaseCurrenciesViewController: UITableViewController {
         }
     }
 
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let currencies = self.currencies {
             return currencies.count
         } else {
@@ -34,9 +35,9 @@ class CoinbaseCurrenciesViewController: UITableViewController {
         }
     }
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell
     {
-        let cell = tableView.dequeueReusableCellWithIdentifier("currency")
+        let cell = tableView.dequeueReusableCell(withIdentifier: "currency")
 
         let label = cell?.viewWithTag(1) as? UILabel
 

--- a/Pod/Classes/OAuth/CoinbaseOAuth.h
+++ b/Pod/Classes/OAuth/CoinbaseOAuth.h
@@ -21,6 +21,7 @@ extern NSString *const CoinbaseOAuthErrorUserInfoKey;
 /// `CoinbaseOAuth` contains methods to authenticate users through OAuth2. After obtaining an
 /// access token using this class, you can call Coinbase API methods
 /// using `[Coinbase coinbaseWithOAuthAccessToken:]`.
+NS_EXTENSION_UNAVAILABLE_IOS("OAuth is currently not allowed in extensions")
 @interface CoinbaseOAuth : NSObject
 
 /// Test if the Coinbase app is installed and if the OAuth authentication process will use the Coinbase


### PR DESCRIPTION
- Updated Swift code to Swift 3.0
- Added `NS_EXTENSION_UNAVAILABLE_IOS` macro, as OAuth is currently not allowed in extensions.
